### PR TITLE
allow spaces in mission descriptions on `QuestResult` page

### DIFF
--- a/magica/template/quest/QuestResult.html
+++ b/magica/template/quest/QuestResult.html
@@ -27,7 +27,8 @@
 			%>
 			<div class="missionTextBox<%= missionClass %>" id="missionText<%= index+1 %>">
 				<%
-					var missionDescription = mission.description.replace(/\s+/g,"");
+					// FIX(LiviaMedeiros): remove `.replace(/\s+/g,"")`, allowing spaces in mission descriptions
+					var missionDescription = mission.description;
 				%>
 				<div class="textWrap"><p class="c_white"><%= missionDescription %></p></div>
 				<div class="clearSprite<% if(missionStatus === 'CLEAR'){ %> anim<% } %>"></div>


### PR DESCRIPTION
Fixes: https://github.com/Puella-Care/totentanz-meta/issues/61

`word-wrap: break-word` is already set for these and `letter-spacing` is not adjusted (in some places it is...), so this should fix the issue.
Long mission descriptions (e.g. `Clear with <long M-Girl name> on your team`) might take more than 2 lines.